### PR TITLE
Add build workflow for AVR128DA

### DIFF
--- a/.github/workflows/build-avr128da.yml
+++ b/.github/workflows/build-avr128da.yml
@@ -1,0 +1,21 @@
+name: Build AVR128DA
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install AVR GCC
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-avr avr-libc
+
+      - name: Compile example
+        run: |
+          avr-g++ -mmcu=avr128da28 -std=c++20 -Os -Werror -c tests/compile_test.cpp -o compile_test.o

--- a/tests/compile_test.cpp
+++ b/tests/compile_test.cpp
@@ -1,0 +1,16 @@
+#include <avr/io.h>
+#include "InterruptDispatcher.h"
+
+class DummyHandler {
+public:
+    static constexpr bool canHandleVectNum(unsigned int vectNum) {
+        return vectNum == 1;
+    }
+    static void __vector() {}
+};
+
+template class InterruptDispatcher<DummyHandler>;
+
+int main() {
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add compile test for AVR128DA
- build test with GitHub Actions on push and pull request

## Testing
- `g++ -std=c++20 -c tests/compile_test.cpp -o /tmp/test.o` *(fails: fatal error: avr/io.h: No such file or directory)*