### PR TITLE
Add clang-format configuration and hook

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,4 @@
+BasedOnStyle: Google
+IndentWidth: 4
+ColumnLimit: 80
+UseTab: Never

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,9 @@
+#!/bin/sh
+# Format staged C++ files using clang-format
+command -v clang-format >/dev/null 2>&1 || exit 0
+
+files=$(git diff --cached --name-only --diff-filter=ACMR | grep -E '\.(cpp|hpp|h)$')
+if [ -n "$files" ]; then
+    clang-format -i $files
+    git add $files
+fi

--- a/README.md
+++ b/README.md
@@ -101,6 +101,20 @@ void jmp_main(void) {
 
 ```
 
+## Development
+
+This project provides a Git pre-commit hook that formats staged C++ files using
+`clang-format`. The hook relies on the style defined in `.clang-format` which is
+based on the Google C++ style guide.
+
+Enable the hook with:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+Once configured, `clang-format` will run automatically before each commit.
+
 ## Contributing
 
 Contributions are welcome! If you have suggestions or improvements, feel free to open an issue or submit a pull request.


### PR DESCRIPTION
## Summary
- add `.clang-format` with Google C++ style options
- run clang-format automatically before commits via `.githooks/pre-commit`
- document hook usage in the README

## Testing
- `g++ -std=c++20 -c tests/compile_test.cpp -o /tmp/test.o` *(fails: fatal error: avr/io.h: No such file or directory)*
- `clang-format --version`