### PR TITLE
Add clang-tidy workflow

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,2 @@
+Checks: '-*,clang-analyzer-*'
+WarningsAsErrors: 'clang-analyzer-*'

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -1,0 +1,24 @@
+name: clang-tidy
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  tidy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install AVR GCC 14.1.0
+        run: |
+          wget -q https://github.com/ZakKemble/avr-gcc-build/releases/download/v14.1.0-1/avr-gcc-14.1.0-x64-linux.tar.bz2
+          tar -xf avr-gcc-14.1.0-x64-linux.tar.bz2
+          echo "$(pwd)/avr-gcc-14.1.0-x64-linux/bin" >> "$GITHUB_PATH"
+
+      - name: Run clang-tidy
+        run: |
+          clang-tidy tests/compile_test.cpp -- \
+            -mmcu=avr128da28 -std=c++20 \
+            -I. -I$(pwd)/avr-gcc-14.1.0-x64-linux/avr/include

--- a/README.md
+++ b/README.md
@@ -115,6 +115,9 @@ git config core.hooksPath .githooks
 
 Once configured, `clang-format` will run automatically before each commit.
 
+Clang-Tidy is executed in the GitHub Actions workflow to catch common
+mistakes. The checks are configured in `.clang-tidy`.
+
 ## Contributing
 
 Contributions are welcome! If you have suggestions or improvements, feel free to open an issue or submit a pull request.


### PR DESCRIPTION
## Summary
- add `.clang-tidy` with basic checks
- add CI workflow to run clang-tidy
- document the new check in README

## Testing
- `g++ -std=c++20 -I. tests/compile_test.cpp -o /tmp/test` *(fails: `avr/io.h` not found)*
- `true`