### PR TITLE
Update workflow to include header

### DIFF
--- a/.github/workflows/update-copyright-year.yml
+++ b/.github/workflows/update-copyright-year.yml
@@ -32,8 +32,8 @@ jobs:
         uses: p3lim/license-year-updater@v2
         with:
           files: |
-            LICENSE
-            InterruptDispatcher.h
+            ./LICENSE
+            ./InterruptDispatcher.h
 
       - name: Create pull request
         uses: peter-evans/create-pull-request@v7


### PR DESCRIPTION
## Summary
- update update-copyright-year workflow to include InterruptDispatcher.h

## Testing
- `avr-g++ -mmcu=avr128da28 -std=c++20 -Os -Werror -I. -c tests/compile_test.cpp -o compile_test.o` *(fails: command not found)*