### PR TITLE
Add CI check for nop-nop-rjmp sequence

### DIFF
--- a/.github/workflows/build-avr128da.yml
+++ b/.github/workflows/build-avr128da.yml
@@ -20,3 +20,20 @@ jobs:
       - name: Compile example
         run: |
           avr-g++ -mmcu=avr128da28 -std=c++20 -Os -Werror -I. -c tests/compile_test.cpp -o compile_test.o
+
+      - name: Verify exact ASM sequence globally
+        run: |
+          # Disassemble the object file produced by the previous step
+          avr-objdump -d compile_test.o > disasm.txt
+
+          echo "Checking for exact sequence: nop -> nop -> rjmp (any spacing/labels allowed)"
+          # GNU grep on ubuntu-latest supports -P and -z; -z lets the regex span newlines
+          if grep -zPq 'nop\s*\n.*nop\s*\n.*rjmp' disasm.txt; then
+            echo "✅ Found exact asm sequence: nop → nop → rjmp"
+          else
+            echo "❌ Expected asm sequence not found."
+            echo "— Nearby lines with 'nop' for debugging —"
+            grep -n -C2 '\bnop\b' disasm.txt || true
+            echo "Full disassembly is saved as disasm.txt"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
- add a workflow step that disassembles compile_test.o
- fail CI if the nop → nop → rjmp sequence is missing and print context

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68ee0cd5bb3c83319d55af5bb1ef35ad

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Enhanced continuous integration to automatically verify a specific assembly instruction sequence during builds. The workflow now disassembles generated output, checks for the expected pattern, and provides diagnostic output on failure. This improves build reliability and catches regressions earlier without impacting the user-facing functionality or public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->