### PR TITLE
Clarify vector macro guard error message

### DIFF
--- a/InterruptDispatcher.h
+++ b/InterruptDispatcher.h
@@ -16,6 +16,10 @@
  * You may use, modify, and distribute it under the terms of the MIT License.
  */
 
+#if !defined _VECTOR_SIZE || !defined _VECTORS_SIZE
+#error "Required macros _VECTORS_SIZE and _VECTOR_SIZE are undefined. Include the appropriate device header before this file."
+#endif
+
 using InterruptVectFuncPtr = void (*)(); // Define a function pointer type for interrupt vectors
 
 // Declare existing external interrupt vector functions


### PR DESCRIPTION
## Summary
- refine the preprocessor error message for missing `_VECTORS_SIZE`/`_VECTOR_SIZE` macros

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68ef7ec1bb14833180cdb028dcfb1990

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a compile-time validation to ensure required configuration is present, providing clearer error messages during builds.
  * Improves build-time robustness and developer feedback without altering runtime behavior.
  * No changes to public APIs or user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->