### PR TITLE
Expand AVR build matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,10 +37,18 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      - name: Cache AVR GCC 14.1.0
+        uses: actions/cache@v4
+        with:
+          path: avr-gcc-14.1.0-x64-linux
+          key: avr-gcc-14.1.0-${{ runner.os }}
+
       - name: Install AVR GCC 14.1.0
         run: |
-          wget -q https://github.com/ZakKemble/avr-gcc-build/releases/download/v14.1.0-1/avr-gcc-14.1.0-x64-linux.tar.bz2
-          tar -xf avr-gcc-14.1.0-x64-linux.tar.bz2
+          if [ ! -d avr-gcc-14.1.0-x64-linux ]; then
+            wget -q https://github.com/ZakKemble/avr-gcc-build/releases/download/v14.1.0-1/avr-gcc-14.1.0-x64-linux.tar.bz2
+            tar -xf avr-gcc-14.1.0-x64-linux.tar.bz2
+          fi
           echo "$(pwd)/avr-gcc-14.1.0-x64-linux/bin" >> "$GITHUB_PATH"
 
       - name: Compile example (${{ matrix.mmcu }})

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build AVR128DA
+name: Build AVR DA and DB
 
 on:
   pull_request:
@@ -8,6 +8,32 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        mmcu:
+          - avr32da28
+          - avr32da32
+          - avr32da48
+          - avr64da28
+          - avr64da32
+          - avr64da48
+          - avr64da64
+          - avr128da28
+          - avr128da32
+          - avr128da48
+          - avr128da64
+          - avr32db28
+          - avr32db32
+          - avr32db48
+          - avr64db28
+          - avr64db32
+          - avr64db48
+          - avr64db64
+          - avr128db28
+          - avr128db32
+          - avr128db48
+          - avr128db64
     steps:
       - uses: actions/checkout@v5
 
@@ -17,13 +43,14 @@ jobs:
           tar -xf avr-gcc-14.1.0-x64-linux.tar.bz2
           echo "$(pwd)/avr-gcc-14.1.0-x64-linux/bin" >> "$GITHUB_PATH"
 
-      - name: Compile example
+      - name: Compile example (${{ matrix.mmcu }})
         run: |
-          avr-g++ -mmcu=avr128da28 -std=c++20 -Os -Werror -I. -c tests/compile_test.cpp -o compile_test.o
+          avr-g++ -mmcu=${{ matrix.mmcu }} -std=c++20 -Os -Werror -I. -c tests/compile_test.cpp -o compile_test.o
 
-      - name: Verify exact ASM sequence globally
+      - name: Verify exact ASM sequence globally (${{ matrix.mmcu }})
         run: |
           # Disassemble the object file produced by the previous step
+          echo "Verifying assembly for ${{ matrix.mmcu }}"
           avr-objdump -d compile_test.o > disasm.txt
 
           echo "Checking for exact sequence: nop -> nop -> rjmp (any spacing/labels allowed)"


### PR DESCRIPTION
## Summary
- rename the AVR workflow to `build.yml` to reflect broader coverage
- expand the build matrix to compile against AVR32/64/128 DA and DB variants

## Testing
- not run (CI only)


------
https://chatgpt.com/codex/tasks/task_b_68f0bb7dc8ec8331b1c1a32c30d2b4a9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Expanded CI build workflow to compile and validate across many additional AVR variants (AVR32DA/64DA/128DA and AVR32DB/64DB/128DB).
  * Added toolchain caching and automated install to ensure consistent builds across runners.

* **Tests**
  * Added an automated verification that checks generated assembly patterns and fails the build if expected instruction sequences are not found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->