### PR TITLE
Add objdump-based vector table verification

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,3 +72,7 @@ jobs:
             echo "Full disassembly is saved as disasm.txt"
             exit 1
           fi
+
+      - name: Verify interrupt vector table layout (${{ matrix.mmcu }})
+        run: |
+          python3 tests/verify_vector_table.py compile_test.o

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,13 +53,13 @@ jobs:
 
       - name: Compile example (${{ matrix.mmcu }})
         run: |
-          avr-g++ -mmcu=${{ matrix.mmcu }} -std=c++20 -Os -Werror -I. -c tests/compile_test.cpp -o compile_test.o
+          avr-g++ -mmcu=${{ matrix.mmcu }} -std=c++20 -Os -Werror -I. -nostartfiles tests/compile_test.cpp -o compile_test.elf
 
       - name: Verify exact ASM sequence globally (${{ matrix.mmcu }})
         run: |
-          # Disassemble the object file produced by the previous step
+          # Disassemble the binary produced by the previous step
           echo "Verifying assembly for ${{ matrix.mmcu }}"
-          avr-objdump -d compile_test.o > disasm.txt
+          avr-objdump -d compile_test.elf > disasm.txt
 
           echo "Checking for exact sequence: nop -> nop -> rjmp (any spacing/labels allowed)"
           # GNU grep on ubuntu-latest supports -P and -z; -z lets the regex span newlines
@@ -75,4 +75,4 @@ jobs:
 
       - name: Verify interrupt vector table layout (${{ matrix.mmcu }})
         run: |
-          python3 tests/verify_vector_table.py compile_test.o
+          python3 tests/verify_vector_table.py compile_test.elf

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,4 +75,17 @@ jobs:
 
       - name: Verify interrupt vector table layout (${{ matrix.mmcu }})
         run: |
+          echo "Dumping section headers for debugging"
+          avr-objdump -h compile_test.elf
+          echo
           python3 tests/verify_vector_table.py compile_test.elf
+
+      - name: Upload compile_test artifacts (${{ matrix.mmcu }})
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: compile-test-${{ matrix.mmcu }}
+          path: |
+            compile_test.elf
+            disasm.txt
+          if-no-files-found: warn

--- a/tests/compile_test.cpp
+++ b/tests/compile_test.cpp
@@ -1,26 +1,54 @@
+#include <avr/interrupt.h>
 #include <avr/io.h>
+
 #include "InterruptDispatcher.h"
 
+int main();
+
+ISR(BADISR_vect) {
+  while (1) {  // Change to your needs
+  }
+}
+
+extern "C" void __dtors_end();
+
+extern "C" void reset(void) __attribute__((used, naked));
+
+extern "C" void reset(void) {
+  asm("clr r1");
+  SREG = 0;
+  SP = RAMEND;
+  goto *&__dtors_end;
+}
+
+extern "C" void _exit();
+
+extern "C" void jmp_main(void) __attribute__((used, naked, section(".init9")));
+
+extern "C" void jmp_main(void) {
+  main();
+  goto *&_exit;
+}
+
 class DummyHandler {
-public:
-    static constexpr bool canHandleVectNum(unsigned int vectNum) {
-        return vectNum == 1;
-    }
-    __attribute__((noreturn)) static void __vector() {
-      asm volatile(
+ public:
+  static constexpr bool canHandleVectNum(unsigned int vectNum) {
+    return vectNum == 1;
+  }
+  __attribute__((noreturn)) static void __vector() {
+    asm volatile(
         "1:   nop       \n\t"
         "     nop       \n\t"
         "     rjmp 1b   \n\t"
         :
         :
-        : "memory"
-      );
-      __builtin_unreachable();
-    }
+        : "memory");
+    __builtin_unreachable();
+  }
 };
 
 template class InterruptDispatcher<false, DummyHandler>;
 
 int main() {
-    return 0;
+  return 0;
 }

--- a/tests/compile_test.cpp
+++ b/tests/compile_test.cpp
@@ -6,7 +6,7 @@
 int main();
 
 ISR(BADISR_vect) {
-  while (1) {  // Change to your needs
+  while (true) {  // Change to your needs
   }
 }
 

--- a/tests/verify_vector_table.py
+++ b/tests/verify_vector_table.py
@@ -20,7 +20,9 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def load_vectors_section(binary_path: Path) -> tuple[list[str], str]:
+def load_vectors_section(
+    binary_path: Path, start: int, end: int
+) -> tuple[list[str], str]:
     result = subprocess.run(
         ["avr-objdump", "-D", str(binary_path)],
         check=False,
@@ -36,10 +38,9 @@ def load_vectors_section(binary_path: Path) -> tuple[list[str], str]:
 
     lines = result.stdout.splitlines()
 
-    section_lines: list[str] = []
+    relevant_lines: dict[int, str] = {}
     current_section = "<unknown>"
     table_section = ""
-    collecting = False
 
     for line in lines:
         stripped = line.strip()
@@ -49,36 +50,21 @@ def load_vectors_section(binary_path: Path) -> tuple[list[str], str]:
 
         parsed = parse_jmp_line(line)
         if not parsed:
-            if collecting and stripped.startswith("0"):
-                # Labels such as "00000000 <symbol>:" should not terminate the table.
-                continue
-            if collecting and stripped:
-                # Encountered the first non-empty, non-JMP line after collecting entries.
-                break
             continue
 
         address, _ = parsed
-        expected_address = len(section_lines) * 4
+        if start <= address < end:
+            relevant_lines[address] = line
+            if not table_section:
+                table_section = current_section
 
-        if not collecting:
-            if address != 0:
-                # Ignore JMPs that are not part of the vector table prefix.
-                continue
-            collecting = True
-            table_section = current_section
-        elif address != expected_address:
-            # We've reached a different block of JMP instructions; stop collecting.
-            break
-
-        section_lines.append(line)
-
-    if not section_lines:  # pragma: no cover - defensive
+    if not relevant_lines:  # pragma: no cover - defensive
         headings = [line.strip() for line in lines if line.startswith("Disassembly of section ")]
         preview = "\n".join(lines[:40])
         message = [
-            "Could not identify a vector-table block in avr-objdump output.",
-            "Looked for a dedicated .vectors section and, failing that, for the",
-            "first sequence of JMP instructions starting at address 0.",
+            "Could not identify vector-table JMPs in avr-objdump output.",
+            "Expected entries covering the address range "
+            f"[{start:#06x}, {end:#06x}).",
         ]
         if headings:
             message.append("Found the following section headers:")
@@ -89,7 +75,54 @@ def load_vectors_section(binary_path: Path) -> tuple[list[str], str]:
         message.append(preview)
         raise RuntimeError("\n".join(message))
 
-    return section_lines, table_section or "<unknown>"
+    ordered = [relevant_lines[address] for address in sorted(relevant_lines)]
+    return ordered, table_section or "<unknown>"
+
+
+_NM_VECTOR_RE = re.compile(r"^([0-9a-fA-F]+)\s+\w\s+(__vectors_(?:start|end))$")
+
+
+def locate_vector_bounds(binary_path: Path) -> tuple[int, int]:
+    result = subprocess.run(
+        ["avr-nm", str(binary_path)],
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+
+    if result.returncode != 0:
+        stderr = result.stderr.strip()
+        raise RuntimeError("avr-nm failed:\n" + (stderr or "(no stderr output)"))
+
+    start = end = None
+    for line in result.stdout.splitlines():
+        match = _NM_VECTOR_RE.match(line.strip())
+        if not match:
+            continue
+        address = int(match.group(1), 16)
+        symbol = match.group(2)
+        if symbol.endswith("start"):
+            start = address
+        else:
+            end = address
+
+    if start is None or end is None:
+        raise RuntimeError(
+            "Could not find __vectors_start/__vectors_end in avr-nm output."
+        )
+
+    if end <= start:
+        raise RuntimeError(
+            f"Vector table end {end:#06x} is not greater than start {start:#06x}."
+        )
+
+    if (end - start) % 4:
+        raise RuntimeError(
+            "Vector table size is not a multiple of 4 bytes: "
+            f"start={start:#06x}, end={end:#06x}"
+        )
+
+    return start, end
 
 
 _JMP_PREFIX_RE = re.compile(
@@ -123,7 +156,14 @@ def main() -> int:
     if not args.binary.exists():
         raise SystemExit(f"Input file '{args.binary}' does not exist")
 
-    section_lines, section_name = load_vectors_section(args.binary)
+    start, end = locate_vector_bounds(args.binary)
+    if start != 0:
+        raise SystemExit(
+            "Expected __vectors_start to resolve to address 0 but it was "
+            f"{start:#06x}"
+        )
+
+    section_lines, section_name = load_vectors_section(args.binary, start, end)
 
     entries = []
     for line in section_lines:
@@ -136,19 +176,21 @@ def main() -> int:
     if not entries:
         raise SystemExit("Did not find any jmp entries while parsing the vector table")
 
-    if entries[0][0] != 0:
+    if entries[0][0] != start:
         raise SystemExit(
             "Expected first vector entry at address 0, but found line:\n" + entries[0][2]
         )
 
-    if len(entries) < 3:
+    expected_entries = (end - start) // 4
+    if len(entries) != expected_entries:
         raise SystemExit(
-            "Vector table appears truncated; expected at least 3 entries but "
-            f"found {len(entries)}"
+            "Vector table entry count mismatch: expected "
+            f"{expected_entries} entries for range [{start:#06x}, {end:#06x}) "
+            f"but found {len(entries)}"
         )
 
     for index, (address, symbol, line) in enumerate(entries):
-        expected_address = index * 4
+        expected_address = start + index * 4
         if address != expected_address:
             raise SystemExit(
                 f"Vector {index} should be at byte offset {expected_address:#x} but line was:\n{line}"

--- a/tests/verify_vector_table.py
+++ b/tests/verify_vector_table.py
@@ -11,16 +11,18 @@ from pathlib import Path
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
-        "object_file",
+        "binary",
         type=Path,
-        help="Path to the AVR object file that contains the interrupt vector table.",
+        help=(
+            "Path to the AVR ELF or object file that contains the interrupt vector table."
+        ),
     )
     return parser.parse_args()
 
 
-def load_vectors_section(obj_path: Path) -> list[str]:
+def load_vectors_section(binary_path: Path) -> list[str]:
     result = subprocess.run(
-        ["avr-objdump", "-D", str(obj_path)],
+        ["avr-objdump", "-D", str(binary_path)],
         check=False,
         text=True,
         capture_output=True,
@@ -71,10 +73,10 @@ def classify_symbol(symbol: str) -> str:
 
 def main() -> int:
     args = parse_args()
-    if not args.object_file.exists():
-        raise SystemExit(f"Object file '{args.object_file}' does not exist")
+    if not args.binary.exists():
+        raise SystemExit(f"Input file '{args.binary}' does not exist")
 
-    section_lines = load_vectors_section(args.object_file)
+    section_lines = load_vectors_section(args.binary)
 
     non_empty = next((line for line in section_lines if line.strip()), "")
     if not non_empty.startswith("00000000 "):

--- a/tests/verify_vector_table.py
+++ b/tests/verify_vector_table.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Check that the generated .vectors table points at the expected symbols."""
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+from pathlib import Path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "object_file",
+        type=Path,
+        help="Path to the AVR object file that contains the interrupt vector table.",
+    )
+    return parser.parse_args()
+
+
+def load_vectors_section(obj_path: Path) -> list[str]:
+    result = subprocess.run(
+        ["avr-objdump", "-D", str(obj_path)],
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+
+    if result.returncode != 0:
+        stderr = result.stderr.strip()
+        raise RuntimeError(
+            "avr-objdump failed:\n" + (stderr or "(no stderr output)")
+        )
+
+    lines = result.stdout.splitlines()
+    start_index = None
+    for idx, line in enumerate(lines):
+        if line.strip() == "Disassembly of section .vectors:":
+            start_index = idx + 1
+            break
+    if start_index is None:  # pragma: no cover - defensive
+        raise RuntimeError("Could not find .vectors section in avr-objdump output")
+
+    section_lines: list[str] = []
+    for line in lines[start_index:]:
+        if line.startswith("Disassembly of section "):
+            break
+        section_lines.append(line)
+
+    # Strip trailing empty lines that objdump sometimes leaves around.
+    while section_lines and not section_lines[-1].strip():
+        section_lines.pop()
+
+    return section_lines
+
+
+_JMP_RE = re.compile(
+    r"^\s*([0-9a-fA-F]+):\s+(?:[0-9a-fA-F]{2}\s+){2,}\s+jmp\s+(?:0x)?[0-9a-fA-F]+\s+<([^>]+)>"
+)
+
+
+def classify_symbol(symbol: str) -> str:
+    if symbol.startswith("reset"):
+        return "reset"
+    if "DummyHandler" in symbol and "__vector" in symbol:
+        return "dummy"
+    if "__vector_default" in symbol:
+        return "default"
+    return "other"
+
+
+def main() -> int:
+    args = parse_args()
+    if not args.object_file.exists():
+        raise SystemExit(f"Object file '{args.object_file}' does not exist")
+
+    section_lines = load_vectors_section(args.object_file)
+
+    non_empty = next((line for line in section_lines if line.strip()), "")
+    if not non_empty.startswith("00000000 "):
+        raise SystemExit(
+            "Expected .vectors to start at address 0, but first line was:\n" + non_empty
+        )
+
+    entries = []
+    for line in section_lines:
+        match = _JMP_RE.search(line)
+        if not match:
+            continue
+        address = int(match.group(1), 16)
+        symbol = match.group(2)
+        entries.append((address, symbol, line))
+
+    if not entries:
+        raise SystemExit("Did not find any jmp entries in the .vectors section")
+
+    for index, (address, symbol, line) in enumerate(entries):
+        expected_address = index * 4
+        if address != expected_address:
+            raise SystemExit(
+                f"Vector {index} should be at byte offset {expected_address:#x} but line was:\n{line}"
+            )
+
+        classification = classify_symbol(symbol)
+        if index == 0:
+            if classification != "reset":
+                raise SystemExit(
+                    f"Vector 0 should jump to reset but instead targets '{symbol}'"
+                )
+        elif index == 1:
+            if classification != "dummy":
+                raise SystemExit(
+                    "Vector 1 should jump to DummyHandler::__vector but line was:\n" + line
+                )
+        else:
+            if classification != "default":
+                raise SystemExit(
+                    f"Vector {index} should jump to __vector_default but line was:\n" + line
+                )
+
+    print(
+        f"Validated {len(entries)} interrupt vectors: reset, DummyHandler, and {len(entries) - 2} defaults."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except RuntimeError as err:
+        raise SystemExit(str(err))

--- a/tests/verify_vector_table.py
+++ b/tests/verify_vector_table.py
@@ -229,4 +229,4 @@ if __name__ == "__main__":
     try:
         raise SystemExit(main())
     except RuntimeError as err:
-        raise SystemExit(str(err))
+        raise SystemExit(str(err)) from err

--- a/tests/verify_vector_table.py
+++ b/tests/verify_vector_table.py
@@ -126,7 +126,7 @@ def locate_vector_bounds(binary_path: Path) -> tuple[int, int]:
 
 
 _JMP_PREFIX_RE = re.compile(
-    r"^\s*([0-9a-fA-F]+):\s+(?:[0-9a-fA-F]{2}\s+){2,}\s+jmp\b", re.IGNORECASE
+    r"^\s*([0-9a-fA-F]+):\s+(?:[0-9a-fA-F]{2}\s+){2,}\s+r?jmp\b", re.IGNORECASE
 )
 
 

--- a/tests/verify_vector_table.py
+++ b/tests/verify_vector_table.py
@@ -37,7 +37,8 @@ def load_vectors_section(binary_path: Path) -> list[str]:
     lines = result.stdout.splitlines()
     start_index = None
     for idx, line in enumerate(lines):
-        if line.strip() == "Disassembly of section .vectors:":
+        stripped = line.strip()
+        if stripped.startswith("Disassembly of section .vectors"):
             start_index = idx + 1
             break
     if start_index is None:  # pragma: no cover - defensive

--- a/tests/verify_vector_table.py
+++ b/tests/verify_vector_table.py
@@ -126,7 +126,7 @@ def locate_vector_bounds(binary_path: Path) -> tuple[int, int]:
 
 
 _JMP_PREFIX_RE = re.compile(
-    r"^\s*([0-9a-fA-F]+):\s+(?:[0-9a-fA-F]{2}\s+){2,}\s+r?jmp\b", re.IGNORECASE
+    r"^\s*([0-9a-fA-F]+):\s+(?:[0-9a-fA-F]{2}\s+){2,}\s+jmp\b", re.IGNORECASE
 )
 
 

--- a/tests/verify_vector_table.py
+++ b/tests/verify_vector_table.py
@@ -42,7 +42,17 @@ def load_vectors_section(binary_path: Path) -> list[str]:
             start_index = idx + 1
             break
     if start_index is None:  # pragma: no cover - defensive
-        raise RuntimeError("Could not find .vectors section in avr-objdump output")
+        headings = [line.strip() for line in lines if line.startswith("Disassembly of section ")]
+        preview = "\n".join(lines[:40])
+        message = ["Could not find .vectors section in avr-objdump output."]
+        if headings:
+            message.append("Found the following section headers:")
+            message.extend(f"  {header}" for header in headings)
+        else:
+            message.append("No disassembly section headers were present in the output.")
+        message.append("First 40 lines of avr-objdump output:")
+        message.append(preview)
+        raise RuntimeError("\n".join(message))
 
     section_lines: list[str] = []
     for line in lines[start_index:]:


### PR DESCRIPTION
## Summary
- add a Python helper that parses `avr-objdump -D` output and checks the `.vectors` section layout
- extend the build workflow to run the new verification for every MCU in the matrix

## Testing
- not run (AVR toolchain unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_b_68f0df5af2788331963a8814e513c34d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a verifier that disassembles the built ELF and enforces AVR interrupt vector ordering, exact addresses, expected handler classifications, section fallback handling, and clear descriptive failures.

* **Chores**
  * CI now builds and validates an ELF binary, adds a dedicated vector-table verification step, and always uploads the ELF and disassembly artifacts (warns if none found).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->