### PR TITLE
Add relative jump compile test and extend CI coverage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,34 +51,59 @@ jobs:
           fi
           echo "$(pwd)/avr-gcc-14.1.0-x64-linux/bin" >> "$GITHUB_PATH"
 
-      - name: Compile example (${{ matrix.mmcu }})
+      - name: Compile absolute-jump example (${{ matrix.mmcu }})
         run: |
-          avr-g++ -mmcu=${{ matrix.mmcu }} -std=c++20 -Os -Werror -I. -nostartfiles tests/compile_test.cpp -o compile_test.elf
+          avr-g++ -mmcu=${{ matrix.mmcu }} -std=c++20 -Os -Werror -I. -nostartfiles tests/compile_test.cpp -o compile_test_abs.elf
 
-      - name: Verify exact ASM sequence globally (${{ matrix.mmcu }})
+      - name: Verify absolute-jump ASM sequence (${{ matrix.mmcu }})
         run: |
-          # Disassemble the binary produced by the previous step
-          echo "Verifying assembly for ${{ matrix.mmcu }}"
-          avr-objdump -d compile_test.elf > disasm.txt
+          echo "Verifying absolute jump assembly for ${{ matrix.mmcu }}"
+          avr-objdump -d compile_test_abs.elf > disasm_abs.txt
 
           echo "Checking for exact sequence: nop -> nop -> rjmp (any spacing/labels allowed)"
-          # GNU grep on ubuntu-latest supports -P and -z; -z lets the regex span newlines
-          if grep -zPq 'nop\s*\n.*nop\s*\n.*rjmp' disasm.txt; then
+          if grep -zPq 'nop\s*\n.*nop\s*\n.*rjmp' disasm_abs.txt; then
             echo "✅ Found exact asm sequence: nop → nop → rjmp"
           else
             echo "❌ Expected asm sequence not found."
             echo "— Nearby lines with 'nop' for debugging —"
-            grep -n -C2 '\bnop\b' disasm.txt || true
-            echo "Full disassembly is saved as disasm.txt"
+            grep -n -C2 '\bnop\b' disasm_abs.txt || true
+            echo "Full disassembly is saved as disasm_abs.txt"
             exit 1
           fi
 
-      - name: Verify interrupt vector table layout (${{ matrix.mmcu }})
+      - name: Verify absolute-jump vector table layout (${{ matrix.mmcu }})
         run: |
           echo "Dumping section headers for debugging"
-          avr-objdump -h compile_test.elf
+          avr-objdump -h compile_test_abs.elf
           echo
-          python3 tests/verify_vector_table.py compile_test.elf
+          python3 tests/verify_vector_table.py compile_test_abs.elf
+
+      - name: Compile relative-jump example (${{ matrix.mmcu }})
+        run: |
+          avr-g++ -mmcu=${{ matrix.mmcu }} -std=c++20 -Os -Werror -I. -nostartfiles tests/compile_test_relative.cpp -o compile_test_rel.elf
+
+      - name: Verify relative-jump ASM sequence (${{ matrix.mmcu }})
+        run: |
+          echo "Verifying relative jump assembly for ${{ matrix.mmcu }}"
+          avr-objdump -d compile_test_rel.elf > disasm_rel.txt
+
+          echo "Checking for exact sequence: nop -> nop -> rjmp (any spacing/labels allowed)"
+          if grep -zPq 'nop\s*\n.*nop\s*\n.*rjmp' disasm_rel.txt; then
+            echo "✅ Found exact asm sequence: nop → nop → rjmp"
+          else
+            echo "❌ Expected asm sequence not found."
+            echo "— Nearby lines with 'nop' for debugging —"
+            grep -n -C2 '\bnop\b' disasm_rel.txt || true
+            echo "Full disassembly is saved as disasm_rel.txt"
+            exit 1
+          fi
+
+      - name: Verify relative-jump vector table layout (${{ matrix.mmcu }})
+        run: |
+          echo "Dumping section headers for debugging"
+          avr-objdump -h compile_test_rel.elf
+          echo
+          python3 tests/verify_vector_table.py compile_test_rel.elf
 
       - name: Upload compile_test artifacts (${{ matrix.mmcu }})
         if: always()
@@ -86,6 +111,8 @@ jobs:
         with:
           name: compile-test-${{ matrix.mmcu }}
           path: |
-            compile_test.elf
-            disasm.txt
+            compile_test_abs.elf
+            disasm_abs.txt
+            compile_test_rel.elf
+            disasm_rel.txt
           if-no-files-found: warn

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,7 +76,7 @@ jobs:
           echo "Dumping section headers for debugging"
           avr-objdump -h compile_test_abs.elf
           echo
-          python3 tests/verify_vector_table.py compile_test_abs.elf
+          python3 tests/verify_vector_table.py --expected-mnemonic jmp compile_test_abs.elf
 
       - name: Compile relative-jump example (${{ matrix.mmcu }})
         run: |
@@ -103,7 +103,7 @@ jobs:
           echo "Dumping section headers for debugging"
           avr-objdump -h compile_test_rel.elf
           echo
-          python3 tests/verify_vector_table.py compile_test_rel.elf
+          python3 tests/verify_vector_table.py --expected-mnemonic rjmp compile_test_rel.elf
 
       - name: Upload compile_test artifacts (${{ matrix.mmcu }})
         if: always()

--- a/tests/compile_test_common.h
+++ b/tests/compile_test_common.h
@@ -1,0 +1,53 @@
+#ifndef COMPILE_TEST_COMMON_H_
+#define COMPILE_TEST_COMMON_H_
+
+#include <avr/interrupt.h>
+#include <avr/io.h>
+
+#include "InterruptDispatcher.h"
+
+int main();
+
+ISR(BADISR_vect) {
+  while (true) {
+  }
+}
+
+extern "C" void __dtors_end();
+
+extern "C" void reset(void) __attribute__((used, naked));
+
+extern "C" void reset(void) {
+  asm("clr r1");
+  SREG = 0;
+  SP = RAMEND;
+  goto *&__dtors_end;
+}
+
+extern "C" void _exit();
+
+extern "C" void jmp_main(void) __attribute__((used, naked, section(".init9")));
+
+extern "C" void jmp_main(void) {
+  main();
+  goto *&_exit;
+}
+
+class DummyHandler {
+ public:
+  static constexpr bool canHandleVectNum(unsigned int vectNum) {
+    return vectNum == 1;
+  }
+  __attribute__((noreturn)) static void __vector() {
+    asm volatile(
+        "1:   nop       \n\t"
+        "     nop       \n\t"
+        "     rjmp 1b   \n\t"
+        :
+        :
+        : "memory");
+    __builtin_unreachable();
+  }
+};
+
+#endif  // COMPILE_TEST_COMMON_H_

--- a/tests/compile_test_relative.cpp
+++ b/tests/compile_test_relative.cpp
@@ -1,6 +1,6 @@
 #include "compile_test_common.h"
 
-template class InterruptDispatcher<false, DummyHandler>;
+template class InterruptDispatcher<true, DummyHandler>;
 
 int main() {
   return 0;

--- a/tests/verify_vector_table.py
+++ b/tests/verify_vector_table.py
@@ -126,7 +126,7 @@ def locate_vector_bounds(binary_path: Path) -> tuple[int, int]:
 
 
 _JMP_PREFIX_RE = re.compile(
-    r"^\s*([0-9a-fA-F]+):\s+(?:[0-9a-fA-F]{2}\s+){2,}\s+jmp\b", re.IGNORECASE
+    r"^\s*([0-9a-fA-F]+):\s+(?:[0-9a-fA-F]{2}\s+){2,}\s+r?jmp\b", re.IGNORECASE
 )
 
 


### PR DESCRIPTION
## Summary
- refactor the compile test into a shared harness header
- add a second test instantiating InterruptDispatcher with relative jumps
- extend the CI workflow to build and validate both absolute and relative jump variants
- relax the vector table verifier to accept either jmp or rjmp entries

## Testing
- python3 -m compileall tests/verify_vector_table.py

------
https://chatgpt.com/codex/tasks/task_b_6901bfeed7ac8331af207a2bcf9920bd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded compile-time tests to cover both absolute and relative jump variants, with a simplified common test harness and explicit instantiation to ensure coverage.
  * Enhanced vector-table validation to check entry sizes dynamically and verify expected instruction mnemonic (jmp vs rjmp).

* **Chores**
  * CI updated to run separate absolute/relative workflows, produce distinct artifacts for each scenario, and clarify logs and outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->