### PR TITLE
Fix regex character class duplication in vector table verification

### DIFF
--- a/tests/verify_vector_table.py
+++ b/tests/verify_vector_table.py
@@ -144,7 +144,7 @@ def locate_vector_bounds(binary_path: Path) -> tuple[int, int]:
 
 
 _JMP_PREFIX_RE = re.compile(
-    r"^\s*([0-9a-fA-F]+):\s+(?:[0-9a-fA-F]{2}\s+){2,}\s+(r?jmp)\b",
+    r"^\s*([0-9a-f]+):\s+(?:[0-9a-f]{2}\s+){2,}\s+(r?jmp)\b",
     re.IGNORECASE,
 )
 


### PR DESCRIPTION
## Summary
- remove duplicated characters from the `_JMP_PREFIX_RE` regular expression to satisfy the SonarCloud check about repeated characters in character classes

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_6901da64c3c883319483109b536c88c4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Minor normalization of test patterns with no functional impact on verification behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->